### PR TITLE
Pong-52: Adjust css styling to make return to home btn more UX friendly

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -114,7 +114,7 @@ section {
     left: 1.5rem;
     display: flex;
     flex-direction: column;
-    align-items: baseline;
+    align-items: stretch;
 }
 
 .playing-state {
@@ -243,16 +243,17 @@ section {
 }
 
 .return-btn {
-    background-color: transparent;
+    background-color: #1399aa;
     color: #fff;
     padding: 10px 20px;
-    border: none;
+    border: 1px solid white;
     border-radius: 5px;
     cursor: pointer;
     font-size: 16px;
     text-align: center;
     text-decoration: none;
     transition: 0.5s;
+    font-family: inherit;
 }
 
 .return-btn:hover {


### PR DESCRIPTION
[Issue Link](https://github.com/Ramzi-Abidi/Pong/issues/52)

Description: 
"return to home modal" wasn't entirely visible to the user as it was blending in to the background. This pr adds a border and changes background color to be different but still in line with the game board. 

Furthermore, I noticed that font-family for the button isn't consistent with the rest of the game, so I added a property to inherit the same font-family as the rest of the game. 

Finally I changed the options items to be aligned to stretch to stretch the "return to home" button as long as the other items to add more consistency overall.

Testing method:
1.  Open up the game
2. Start a single player game
3. Observe new button style
4. Repeat 2-3 with multiplayer mode

Visual changes:
<img width="838" alt="Screenshot 2024-08-10 at 12 10 02 AM" src="https://github.com/user-attachments/assets/dccc752e-3b44-41be-b6d1-bbf1ac8ddcaa">
