### PR TITLE
fix: add button sounds and improve UX across Settings and OnlineMode

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -155,9 +155,7 @@ section {
 
 .star-github-button {
     display: flex;
-    width: auto;
-    height: auto;
-    padding: 0 5px;
+    padding: .1rem .5rem;
     position: absolute;
     background-color: #f1f1f1;
     top: 1rem;
@@ -187,7 +185,6 @@ section {
     text-align: center;
     background-color: #fff;
     width: 600px;
-    /* height: 500px; */
     border-radius: 6px;
     padding: 1rem;
     margin-top: 5rem;
@@ -214,6 +211,10 @@ section {
     bottom: 0;
     display: flex;
     color: #333;
+}
+
+.menu .checkbox h4 {
+    margin-left: 0.5rem;
 }
 
 .menu .checkbox img {
@@ -260,11 +261,6 @@ section {
     background: #15b8cd0a;
     color: #15b7cd;
 }
-
-/* .return-btn:focus {
-    outline: none;
-    box-shadow: 0 0 5px #15b7cd;
-} */
 
 .game-paused-info {
     position: absolute;

--- a/src/views/OnlineMode.tsx
+++ b/src/views/OnlineMode.tsx
@@ -233,8 +233,8 @@ const OnlineMode: React.FC = () => {
                 join: { text: "Join Room", value: "join" },
                 cancel: { text: "Back", value: "cancel" }
             } as any,
-            closeOnClickOutside: false,
-            closeOnEsc: false,
+            closeOnClickOutside: true,
+            closeOnEsc: true,
         });
 
         if (choice === "cancel") {
@@ -246,10 +246,18 @@ const OnlineMode: React.FC = () => {
         const name = await swal({
             title: "Enter your name",
             content: "input" as any,
-            buttons: { confirm: { text: "Next", value: true } },
-            closeOnClickOutside: false,
-            closeOnEsc: false,
+            buttons: {
+                cancel: { text: "Back", value: "cancel" },
+                confirm: { text: "Next", value: true }
+            } as any,
+            closeOnClickOutside: true,
+            closeOnEsc: true,
         });
+
+        if (name === "cancel") {
+            showJoinCreateMenu();
+            return;
+        }
 
         if (!name) {
             showJoinCreateMenu();
@@ -264,10 +272,18 @@ const OnlineMode: React.FC = () => {
             const code = await swal({
                 title: "Enter Room Code",
                 content: "input" as any,
-                buttons: { confirm: { text: "Join", value: true } },
-                closeOnClickOutside: false,
-                closeOnEsc: false,
+                buttons: {
+                    cancel: { text: "Back", value: "cancel" },
+                    confirm: { text: "Join", value: true }
+                } as any,
+                closeOnClickOutside: true,
+                closeOnEsc: true,
             });
+
+            if (code === "cancel") {
+                showJoinCreateMenu();
+                return;
+            }
 
             if (!code) {
                 showJoinCreateMenu();
@@ -381,12 +397,13 @@ const OnlineMode: React.FC = () => {
     }, [isBlurry]);
 
     const playSound = () => {
-        const audio = new Audio(buttonClickSound);
-        if (isSoundOn) audio.play();
+        if (isSoundOn) {
+            const audio = new Audio(buttonClickSound);
+            audio.play().catch(e => console.log('Audio play failed:', e));
+        }
     };
 
     const handleReturnToMenu = () => {
-        playSound();
         swal({
             title: "Leave Match?",
             text: "This will disconnect you from the online game.",
@@ -417,7 +434,13 @@ const OnlineMode: React.FC = () => {
                 <span className="playing-state">
                     Status: <span style={{ color: connectionStatus === "Connected" ? "#4CAF50" : "#F44336" }}>{connectionStatus}</span>
                 </span>
-                <button onClick={handleReturnToMenu} className="return-btn">
+                <button
+                    onClick={() => {
+                        handleReturnToMenu();
+                        playSound();
+                    }}
+                    className="return-btn"
+                >
                     Return to menu
                 </button>
             </div>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -10,12 +10,14 @@ import {
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import HomeIcon from "@mui/icons-material/Home";
+import buttonClickSound from "../assets/button-click-sound.mp3";
 import { useAppStore, GameSettings } from "../store/useAppStore";
 
 const Settings = () => {
     const navigate = useNavigate();
     const storeSettings = useAppStore((state) => state.settings);
     const updateSettings = useAppStore((state) => state.updateSettings);
+    const isSoundOn = useAppStore((state) => state.isSoundOn);
 
     const [localSettings, setLocalSettings] = useState<GameSettings>(storeSettings);
 
@@ -29,7 +31,15 @@ const Settings = () => {
         setLocalSettings({ ...localSettings, pointOption: option });
     };
 
+    const playSound = () => {
+        if (isSoundOn) {
+            const audio = new Audio(buttonClickSound);
+            audio.play();
+        }
+    };
+
     const onSave = () => {
+        playSound();
         updateSettings(localSettings);
         navigate("/");
     };


### PR DESCRIPTION
fix: add button sounds and improve UX across Settings and OnlineMode

- Add button click sound to Settings "Save & Go Home" btn
- Fix OnlineMode playSound to check isSoundOn
- Add "Back" buttons to OnlineMode name/room code input prompts
- Enable closeOnClickOutside and closeOnEsc for all OnlineMode sweetalerts
- Update OnlineMode "Return to menu" button to match SinglePlayerMode/MultiplePlayerMode pattern